### PR TITLE
Update accounts/views.py (ChatGPT)

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -106,11 +106,9 @@ def premium_dashboard(request):
         'selected_difficulty': selected_difficulty,
     })
 
-
-
 def logout_view(request):
     logout(request)
-    return redirect('login')  # Redirect to login page after logout
+    return redirect('login') if 'login' in request.GET else redirect('/') 
 
        
 #stripe
@@ -152,16 +150,3 @@ def update_difficulty(request):
     else:
         form = DifficultyForm(instance=profile)
     return render(request, 'accounts/update_difficulty.html', {'form': form})
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Automated edit.

Goal:
Create or replace a function-based view named logout_view that logs out the current user with django.contrib.auth.logout(request) and then redirects to the 'login' URL name if it exists, otherwise to '/'. Do not render any template. The view should accept GET and POST safely. Keep the rest of the file unchanged. Do not include markdown fences in the output.
Branch: `chatgpt/edit-20250813-175306`