### PR TITLE
Update accounts/urls.py (ChatGPT)

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,14 @@
 # accounts/urls.py
-from django.urls import path
-from . import views
-from .views import update_difficulty, register_view
+from django.urls import path, include
+from .views import update_difficulty, register_view, logout_view
+
+app_name = 'accounts'
 
 urlpatterns = [
+    path('logout/', logout_view, name='logout'),
     path('update-difficulty/', update_difficulty, name='update_difficulty'),
     path('register/', register_view, name='register'),   # ✅ custom register page
     path('dashboard/', views.dashboard, name='dashboard'),
     path('premium-dashboard/', views.premium_dashboard, name='premium_dashboard'),
+    path('', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Create or update this module to: from django.urls import path, include; from .views import logout_view; app_name='accounts'; urlpatterns=[ path('logout/', logout_view, name='logout'), path('', include('django.contrib.auth.urls')), ]; Ensure the logout path appears BEFORE including django.contrib.auth.urls so it overrides the POST-only LogoutView. Keep any existing patterns but ensure ordering like above. No markdown fences.
Branch: `chatgpt/edit-20250813-182030`