### PR TITLE
Update projectv1/urls.py (ChatGPT)

### DIFF
--- a/projectv1/urls.py
+++ b/projectv1/urls.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 from django.urls import path, include
-from exercises.views import dashboard_router  # or home_view if you prefer
+from exercises.views import home_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', dashboard_router, name='home'),            # role-based landing
-    path('accounts/', include('accounts.urls')),        # our register view
-    path('accounts/', include('django.contrib.auth.urls')),  # built-in login/logout/password
+    path('', home_view, name='home'),
+    path('accounts/', include('accounts.urls')),
     path('exercises/', include('exercises.urls')),
-    path('payments/', include('payments.urls')),        # optional
+    path('payments/', include('payments.urls')),
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Ensure the root urls.py imports path and include, includes path('accounts/', include('accounts.urls')), and maps '' (the site root) to home_view from exercises.views with name='home'. Remove any direct include('django.contrib.auth.urls') at the project level so accounts.urls controls ordering. Keep all other routes unchanged. No markdown fences.
Branch: `chatgpt/edit-20250813-182526`