### PR TITLE
Update accounts/urls.py (ChatGPT)

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,11 @@
-# accounts/urls.py
-from django.urls import path
-from . import views
-from .views import update_difficulty, register_view
+from django.urls import path, include
+from .views import logout_view, update_difficulty, register_view
 
 urlpatterns = [
+    path('logout/', logout_view, name='logout'),  # our override FIRST
     path('update-difficulty/', update_difficulty, name='update_difficulty'),
     path('register/', register_view, name='register'),   # ✅ custom register page
     path('dashboard/', views.dashboard, name='dashboard'),
     path('premium-dashboard/', views.premium_dashboard, name='premium_dashboard'),
+    path('', include('django.contrib.auth.urls')),
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Replace this module so it exposes a GET/POST-friendly logout. Code (no markdown): 
from django.urls import path, include
from .views import logout_view
app_name = 'accounts'
urlpatterns = [
    path('logout/', logout_view, name='logout'),  # our override FIRST
    path('', include('django.contrib.auth.urls')),
]
Keep nothing else beyond this unless you already have other patterns; if so, keep them but ensure logout/ is defined before including auth urls.
Branch: `chatgpt/edit-20250813-183333`