### PR TITLE
Update projectv1/urls.py (ChatGPT)

### DIFF
--- a/projectv1/urls.py
+++ b/projectv1/urls.py
@@ -5,8 +5,7 @@ from exercises.views import dashboard_router  # or home_view if you prefer
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', dashboard_router, name='home'),            # role-based landing
-    path('accounts/', include('accounts.urls')),        # our register view
-    path('accounts/', include('django.contrib.auth.urls')),  # built-in login/logout/password
+    path('accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),  # our register view
     path('exercises/', include('exercises.urls')),
     path('payments/', include('payments.urls')),        # optional
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Ensure urlpatterns includes the accounts app with a namespace and does not include django.contrib.auth.urls directly. Code (no markdown):
from django.contrib import admin
from django.urls import path, include
from exercises.views import home_view  # ensure this exists
urlpatterns = [
    path('', home_view, name='home'),
    path('accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),
    path('admin/', admin.site.urls),
]
Preserve any other app routes you have, but do not include django.contrib.auth.urls at the project level.
Branch: `chatgpt/edit-20250813-183404`