### PR TITLE
Update accounts/urls.py (ChatGPT)

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,12 @@
-# accounts/urls.py
-from django.urls import path
-from . import views
-from .views import update_difficulty, register_view
+from django.urls import path, include
+from .views import logout_view, update_difficulty, register_view
 
+app_name = 'accounts'
 urlpatterns = [
+    path('logout/', logout_view, name='logout'),  # our override FIRST
     path('update-difficulty/', update_difficulty, name='update_difficulty'),
     path('register/', register_view, name='register'),   # ✅ custom register page
     path('dashboard/', views.dashboard, name='dashboard'),
     path('premium-dashboard/', views.premium_dashboard, name='premium_dashboard'),
+    path('', include('django.contrib.auth.urls')),  # then the rest of auth (login, password, etc.)
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Replace the file with this exact structure (no markdown fences): 
from django.urls import path, include
from .views import logout_view
app_name = 'accounts'
urlpatterns = [
    path('logout/', logout_view, name='logout'),  # our override FIRST
    path('', include('django.contrib.auth.urls')),  # then the rest of auth (login, password, etc.)
]
If there are other existing patterns in this file, keep them, but ensure the logout path appears BEFORE including django.contrib.auth.urls.
Branch: `chatgpt/edit-20250813-183911`