### PR TITLE
Update accounts/urls.py (ChatGPT)

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,11 +1,13 @@
 # accounts/urls.py
-from django.urls import path
-from . import views
-from .views import update_difficulty, register_view
+from django.urls import path, include
+from .views import logout_view, update_difficulty, register_view
 
+app_name = 'accounts'  # <-- namespace anchor
 urlpatterns = [
+    path('logout/', logout_view, name='logout'),      # our GET/POST logout first
     path('update-difficulty/', update_difficulty, name='update_difficulty'),
     path('register/', register_view, name='register'),   # ✅ custom register page
     path('dashboard/', views.dashboard, name='dashboard'),
     path('premium-dashboard/', views.premium_dashboard, name='premium_dashboard'),
+    path('', include('django.contrib.auth.urls')),    # login, password views, etc.
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Replace with a canonical, namespaced urls module (no markdown): 
from django.urls import path, include
from .views import logout_view
app_name = 'accounts'  # <-- namespace anchor
urlpatterns = [
    path('logout/', logout_view, name='logout'),      # our GET/POST logout first
    path('', include('django.contrib.auth.urls')),    # login, password views, etc.
]
Keep any other existing patterns if you have them, but ensure app_name='accounts' and logout/ appears before including auth urls.
Branch: `chatgpt/edit-20250813-185759`