### PR TITLE
Update projectv1/urls.py (ChatGPT)

### DIFF
--- a/projectv1/urls.py
+++ b/projectv1/urls.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 from django.urls import path, include
-from exercises.views import dashboard_router  # or home_view if you prefer
+from exercises.views import home_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', dashboard_router, name='home'),            # role-based landing
-    path('accounts/', include('accounts.urls')),        # our register view
-    path('accounts/', include('django.contrib.auth.urls')),  # built-in login/logout/password
+    path('', home_view, name='home'),
+    path('accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),
     path('exercises/', include('exercises.urls')),
-    path('payments/', include('payments.urls')),        # optional
+    path('payments/', include('payments.urls')),
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Include the accounts app with an explicit namespace and ensure a home route exists. Code (no markdown):
from django.contrib import admin
from django.urls import path, include
from exercises.views import home_view   # make sure this exists
urlpatterns = [
    path('', home_view, name='home'),
    path('accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),
    path('admin/', admin.site.urls),
]
Do NOT include django.contrib.auth.urls directly here (accounts.urls handles it). Preserve other app routes you already have.
Branch: `chatgpt/edit-20250813-185813`