### PR TITLE
Update projectv1/urls.py (ChatGPT)

### DIFF
--- a/projectv1/urls.py
+++ b/projectv1/urls.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 from django.urls import path, include
-from exercises.views import dashboard_router  # or home_view if you prefer
+from exercises.views import home_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', dashboard_router, name='home'),            # role-based landing
-    path('accounts/', include('accounts.urls')),        # our register view
-    path('accounts/', include('django.contrib.auth.urls')),  # built-in login/logout/password
+    path('', home_view, name='home'),
+    path('accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),
     path('exercises/', include('exercises.urls')),
-    path('payments/', include('payments.urls')),        # optional
+    path('payments/', include('payments.urls')),
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Replace/ensure root urls includes: path('accounts/', include(('accounts.urls','accounts'), namespace='accounts')) and maps '' to home_view from exercises.views with name='home'. Do NOT include django.contrib.auth.urls directly at the project level. Keep admin and any other routes. Import path, include, home_view as needed. No markdown.
Branch: `chatgpt/edit-20250814-084144`