### PR TITLE
Update accounts/views.py (ChatGPT)

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -110,7 +110,7 @@ def premium_dashboard(request):
 
 def logout_view(request):
     logout(request)
-    return redirect('login')  # Redirect to login page after logout
+    return redirect(reverse('accounts:login') or '/accounts/login/' or '/')  # Redirect to login page after logout
 
        
 #stripe
@@ -152,16 +152,3 @@ def update_difficulty(request):
     else:
         form = DifficultyForm(instance=profile)
     return render(request, 'accounts/update_difficulty.html', {'form': form})
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Automated edit.

Goal:
Update logout_view(request) so after logout it redirects to the named URL 'accounts:login' if available, otherwise fallback to '/accounts/login/' and then '/'. Keep everything else unchanged. No markdown.
Branch: `chatgpt/edit-20250814-090320`