### PR TITLE
Update projectv1/urls.py (ChatGPT)

### DIFF
--- a/projectv1/urls.py
+++ b/projectv1/urls.py
@@ -1,12 +1,14 @@
 from django.contrib import admin
 from django.urls import path, include
-from exercises.views import dashboard_router  # or home_view if you prefer
+from exercises.views import home_view
+from accounts.views import login_view, register_view, logout_view
 
 urlpatterns = [
+    path('', home_view, name='home'),
+    path('login/', login_view, name='login'),
+    path('register/', register_view, name='register'),
+    path('logout/', logout_view, name='logout'),
     path('admin/', admin.site.urls),
-    path('', dashboard_router, name='home'),            # role-based landing
-    path('accounts/', include('accounts.urls')),        # our register view
-    path('accounts/', include('django.contrib.auth.urls')),  # built-in login/logout/password
     path('exercises/', include('exercises.urls')),
-    path('payments/', include('payments.urls')),        # optional
+    path('payments/', include('payments.urls')),        
 ]


### PR DESCRIPTION
Automated edit.

Goal:
Replace file to expose minimal auth routes at root (no markdown). Code: from django.contrib import admin; from django.urls import path; from accounts.views import login_view, register_view, logout_view; from exercises.views import home_view; urlpatterns=[ path('', home_view, name='home'), path('login/', login_view, name='login'), path('register/', register_view, name='register'), path('logout/', logout_view, name='logout'), path('admin/', admin.site.urls), ]; Do NOT include django.contrib.auth.urls. Keep other app routes only if they existed and do not conflict.
Branch: `chatgpt/edit-20250814-100450`