### PR TITLE
Update templates/accounts/register.html (bridge)

### DIFF
--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container">
+    <h2>Create an Account</h2>
+    <form method="post">
+        {% csrf_token %}
+        <div class="form-group">
+            <label for="id_username">Username:</label>
+            {{ form.username|as_widget(attrs={'class': 'form-control', 'id': 'id_username'}) }}
+            {{ form.username.errors }}
+        </div>
+        <div class="form-group">
+            <label for="id_password1">Password:</label>
+            {{ form.password1|as_widget(attrs={'class': 'form-control', 'id': 'id_password1'}) }}
+            {{ form.password1.errors }}
+        </div>
+        <div class="form-group">
+            <label for="id_password2">Confirm Password:</label>
+            {{ form.password2|as_widget(attrs={'class': 'form-control', 'id': 'id_password2'}) }}
+            {{ form.password2.errors }}
+        </div>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </form>
+    <p class="mt-3">Already have an account? <a href="{% url 'login' %}">Login here</a>.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
Automated edit from ChatGPT bridge.

Goal:
Create or replace with a Bootstrap form rendering Django's UserCreationForm fields (username, password1, password2), extends base.html, includes {% csrf_token %}, has a submit button and a link back to /login/ (no markdown).
Branch: `chatgpt/edit-20250814-121031`